### PR TITLE
increased swtbot.search.timeout to 30s

### DIFF
--- a/scripts/src/main/groovy/testInstall.groovy
+++ b/scripts/src/main/groovy/testInstall.groovy
@@ -59,7 +59,7 @@ void runSWTBotInstallRoutine(File eclipseHome, String productName, String additi
 	proc.setOutput(output);
 	proc.setJvmargs(additionalVMArgs + " " +
 			specificVMArgs   + " " +
-			"-Dorg.eclipse.swtbot.search.timeout=15000 " +
+			"-Dorg.eclipse.swtbot.search.timeout=30000 " +
 			"-Dusage_reporting_enabled=false " +
 			"-Xms256M -Xmx768M -XX:MaxPermSize=512M");
 	proc.setJar(new File(eclipseHome, "plugins").listFiles().find {it.getName().startsWith("org.eclipse.equinox.launcher_") && it.getName().endsWith(".jar")} );


### PR DESCRIPTION
Sometimes when running central swtbot tests the content  is not loaded within 15s and the tests fail on timeout exception. I increased the swtbot.search.timeout to 30s to make the tests more stable.
