### PR TITLE
Increases search timout to 5min.

### DIFF
--- a/scripts/src/main/groovy/testInstall.groovy
+++ b/scripts/src/main/groovy/testInstall.groovy
@@ -96,7 +96,7 @@ void runSWTBotInstallRoutine(File eclipseHome, String productName, String additi
 	proc.setDir(eclipseHome);
 	proc.setJvmargs(additionalVMArgs + " " +
 			specificVMArgs   + " " +
-			"-Dorg.eclipse.swtbot.search.timeout=30000 " +
+			"-Dorg.eclipse.swtbot.search.timeout=300000 " +
 			"-Dusage_reporting_enabled=false " +
 			"-Xms256M -Xmx768M -XX:MaxPermSize=512M");
 	proc.setJar(new File(eclipseHome, "plugins").listFiles().find {it.getName().startsWith("org.eclipse.equinox.launcher_") && it.getName().endsWith(".jar")} );


### PR DESCRIPTION
As a result the test will wait longer for loading content
on Software/Update tab in central. This is a workaround for JBIDE-15082 on windows.
