### PR TITLE
Fix closing welcome page - sometimes there is no active view in eclipse ...

### DIFF
--- a/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/CheckForUpdatesTest.java
+++ b/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/CheckForUpdatesTest.java
@@ -12,6 +12,7 @@ package org.jboss.tools.tests.installation;
 
 import org.eclipse.swtbot.eclipse.finder.SWTBotEclipseTestCase;
 import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.waits.ICondition;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -36,8 +37,10 @@ public class CheckForUpdatesTest extends SWTBotEclipseTestCase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		if (this.bot.activeView().getTitle().equals("Welcome")) {
+		try{
 			this.bot.viewByTitle("Welcome").close();
+		} catch (WidgetNotFoundException e){
+			//no welcome screen open
 		}
 	}
 

--- a/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallFromCentralTest.java
+++ b/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallFromCentralTest.java
@@ -49,8 +49,10 @@ public class InstallFromCentralTest extends SWTBotEclipseTestCase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		if (this.bot.activeView().getTitle().equals("Welcome")) {
+		try{
 			this.bot.viewByTitle("Welcome").close();
+		} catch (WidgetNotFoundException e){
+			//no welcome screen open
 		}
 	}
 

--- a/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallTest.java
+++ b/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallTest.java
@@ -61,8 +61,10 @@ public class InstallTest extends SWTBotEclipseTestCase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		if (this.bot.activeView().getTitle().equals("Welcome")) {
+		try{
 			this.bot.viewByTitle("Welcome").close();
+		} catch (WidgetNotFoundException e){
+			//no welcome screen open
 		}
 	}
 

--- a/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallZipTest.java
+++ b/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallZipTest.java
@@ -53,8 +53,10 @@ public class InstallZipTest extends SWTBotEclipseTestCase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		if (this.bot.activeView().getTitle().equals("Welcome")) {
+		try{
 			this.bot.viewByTitle("Welcome").close();
+		} catch (WidgetNotFoundException e){
+			//no welcome screen open
 		}
 	}
 


### PR DESCRIPTION
...and thus it fails to close the welcome screen ending up with an exception.
