### PR TITLE
JBIDE-24675 Install-grinder won't wait for 'Installing Software' shell

### DIFF
--- a/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallTest.java
+++ b/plugins/org.jboss.tools.tests.installation/src/org/jboss/tools/tests/installation/InstallTest.java
@@ -153,12 +153,12 @@ public class InstallTest extends SWTBotEclipseTestCase {
 			bot.radio(0).click();
 			bot.button("Finish").click();
 			// wait for Security pop-up, or install finished.
-			final SWTBotShell shell = bot.shell(shellTitle);
-			bot.waitWhile(new ICondition() {
+			
+			bot.waitUntil(new ICondition() {
 
 				@Override
 				public boolean test() throws Exception {
-					return shell.isActive();
+					return bot.activeShell().getText().matches("Security Warning|Software Updates");
 				}
 
 				@Override


### PR DESCRIPTION
JBIDE-24675 Fix install-grinder test - it won't wait for 'Installing Software' shell. This shell is not displayed because job runs on background.

Signed-off-by: Lukáš Valach <lvalach@redhat.com>